### PR TITLE
Fix reset function

### DIFF
--- a/CPU.cpp
+++ b/CPU.cpp
@@ -15,8 +15,8 @@ public:
     uint8_t X = 0x00;        // X Register
     uint8_t Y = 0x00;        // Y Register
     uint8_t S = 0xFD;        // Stack Pointer, start at 0xFD
-    uint16_t PC = 0xFFFC;    // Program Counter, start at 0xFFFC;
-    uint8_t P = FLAGS::I;        // Status Flags Register, start with I
+    uint16_t PC = 0x0000;    // Program Counter, read memory at 0xFFFC and 0xFFFD for start of program;
+    uint8_t P = I + U;        // Status Flags Register, start with I and U
 
     // RAM for CPU
     std::array<uint8_t, 64 * 1024> memory{};
@@ -82,9 +82,14 @@ public:
 
     // Set the CPU registers as specified by a console reset
     void reset() {
-      PC = 0xFFFC;
-      S -= 3;
-      setFlag(FLAGS::I, 1);
+        const uint16_t read_address = 0xFFFC;
+        uint16_t lo = readMemory(read_address);
+        uint16_t hi = readMemory(read_address + 1);
+        PC = (hi << 8) | lo;
+        S = 0xFD;
+        P = 0x00;
+        setFlag(I, true);
+        setFlag(U, true);
     }
 
     // Read and execute the next instruction

--- a/tests.cpp
+++ b/tests.cpp
@@ -128,9 +128,22 @@ public:
 		cpu.S = 0xAA;
 		std::cout << "\nUpdated values:\n";
 		cpu.printRegisters();
+
+		// Populate fixed memory address
+		cpu.writeMemory(0xFFFC, 0xA9);
+		cpu.writeMemory(0xFFFD, 0xC2);
+
+		// Reset CPU state
 		cpu.reset();
 		std::cout << "\nAfter reset:\n";
 		cpu.printRegisters();
+
+		//Check if values match reset
+		assert(cpu.P == 0x24);
+		assert(cpu.S == 0xFD);
+		assert(cpu.PC == 0xC2A9);
+
+		std::cout << "---------------------------\nReset function tests passed!\n";
 	}
 
 //----------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
1. PC counter needs to get the two bytes from 0xFFFC and 0xFFFD to get the memory address of where the program starts. NES ROMS use 0xFFFC and 0xFFFD as a fixed memory location that holds the address to the start of the program. 
2. From research, I saw that the U flag should always be set to 1. Even though it is unused, some programs for the NES assume it is always 1 and might cause weird errors if it is not.
3. I updated the test function to reflect these changes and use assertions to test the function.