### PR TITLE
Branch instructions and corresponding tests

### DIFF
--- a/CPU.cpp
+++ b/CPU.cpp
@@ -148,6 +148,16 @@ public:
         instructionTable[0x28] = {&CPU::PLP, &CPU::Implied};
         instructionTable[0x58] = {&CPU::CLI, &CPU::Implied};
         instructionTable[0x78] = {&CPU::SEI, &CPU::Implied};
+        instructionTable[0xF0] = {&CPU::BEQ, &CPU::Relative};
+        instructionTable[0xD0] = {&CPU::BNE, &CPU::Relative};
+        instructionTable[0x90] = {&CPU::BCC, &CPU::Relative};
+        instructionTable[0xB0] = {&CPU::BCS, &CPU::Relative};
+        instructionTable[0x30] = {&CPU::BMI, &CPU::Relative};
+        instructionTable[0x10] = {&CPU::BPL, &CPU::Relative};
+        instructionTable[0x50] = {&CPU::BVC, &CPU::Relative};
+        instructionTable[0x70] = {&CPU::BVS, &CPU::Relative};
+        instructionTable[0x18] = {&CPU::CLC, &CPU::Implicit};
+        instructionTable[0x38] = {&CPU::SEC, &CPU::Implicit};
     }
 
     // --------------------------------------  Instructions
@@ -257,6 +267,86 @@ public:
       uint8_t value = readMemory(address);
       A = value;
     }
+    
+    
+    // Branch Instructions (8 count)
+	// these are signed, hence int8_t instead of uint8_t
+
+	// branch if Zero flag is set
+	void BEQ(uint16_t address) {
+		if (getFlag(Z)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+
+	// branch if Zero flag is not set
+	void BNE(uint16_t address) {
+		if (!getFlag(Z)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+
+	// branch if Carry flag is set
+	void BCS(uint16_t address) {
+		if (getFlag(C)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+	
+	// branch if Carry flag is not set
+	void BCC(uint16_t address) {
+		if (!getFlag(C)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+
+	// branch if Negative flag is set (Minus)
+	void BMI(uint16_t address) {
+		if (getFlag(N)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+
+	// branch if Negative flag is not set (Plus)
+	void BPL(uint16_t address) {
+		if (!getFlag(N)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+
+	// branch if oVerflow flag is set
+	void BVS(uint16_t address) {
+		if (getFlag(V)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+	
+	// branch if oVerflow flag is not set
+	void BVC(uint16_t address) {
+		if (!getFlag(V)) {
+			int8_t value = readMemory(address);
+			PC = PC + 2 + value;
+		}
+	}
+
+	// Carry Flag Instructions (2 count)
+	
+	//set the carry flag
+	void SEC(uint16_t address) {
+		setFlag(C, true);
+	}
+	
+	// clear the carry flag
+	void CLC(uint16_t address) {
+		setFlag(C, false);
+	}
 
 
     // --------------------------------------  Addressing Modes

--- a/CPU.cpp
+++ b/CPU.cpp
@@ -268,7 +268,8 @@ public:
       A = value;
     }
     
-    
+    // Carter's instructions--------------------------------------------------------
+
     // Branch Instructions (8 count)
 	// these are signed, hence int8_t instead of uint8_t
 

--- a/main.cpp
+++ b/main.cpp
@@ -14,6 +14,7 @@ int main() {
 	tests.test_irq();
 	tests.test_jmp();
 	tests.test_stack_instructions();
+	tests.test_branch();
     return 0;
 }
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -231,6 +231,7 @@ public:
 
 		std::cout << "---------------------------\nJump functions tests passed!\n";
 	}
+
 //----------------------------------------------------------------------------------------------------------------------------
 	void test_stack_instructions() {
 		CPU cpu;
@@ -247,5 +248,62 @@ public:
 		cpu.PLP(test_memory);
 
 		assert(cpu.P == 0x24);
+	}
+
+//----------------------------------------------------------------------------------------------------------------------------
+	void test_branch() {
+		CPU cpu;
+		
+		uint16_t test_memory = 0x0000;
+		cpu.writeMemory(test_memory, 0x78);
+		
+		// branch if Zero set
+		cpu.setFlag(CPU::FLAGS::Z, 1);
+		cpu.BEQ(test_memory);
+		assert(cpu.PC == 0x7A);
+
+		// branch if Zero clear
+		cpu.PC = 0x0000;
+		cpu.setFlag(CPU::FLAGS::Z, 0);
+		cpu.BNE(test_memory);
+		assert(cpu.PC == 0x7A);
+		
+		// branch if Carry set
+		cpu.PC = 0x0000;
+		cpu.setFlag(CPU::FLAGS::C, 1);
+		cpu.BCS(test_memory);
+		assert(cpu.PC == 0x7A);
+
+		// branch if Carry clear
+		cpu.PC = 0x0000;
+		cpu.setFlag(CPU::FLAGS::C, 0);
+		cpu.BCC(test_memory);
+		assert(cpu.PC == 0x7A);
+		
+		// branch if Negative set
+		cpu.PC = 0x0000;
+		cpu.setFlag(CPU::FLAGS::N, 1);
+		cpu.BMI(test_memory);
+		assert(cpu.PC == 0x7A);
+
+		// branch if Negative clear
+		cpu.PC = 0x0000;
+		cpu.setFlag(CPU::FLAGS::N, 0);
+		cpu.BPL(test_memory);
+		assert(cpu.PC == 0x7A);
+		
+		// branch if oVerflow set
+		cpu.PC = 0x0000;
+		cpu.setFlag(CPU::FLAGS::V, 1);
+		cpu.BVS(test_memory);
+		assert(cpu.PC == 0x7A);
+
+		// branch if oVerflow clear
+		cpu.PC = 0x0000;
+		cpu.setFlag(CPU::FLAGS::V, 0);
+		cpu.BVC(test_memory);
+		assert(cpu.PC == 0x7A);	
+		
+		std::cout << "---------------------------\nBranch functions tests passed!\n";
 	}
 };


### PR DESCRIPTION
Updated the instructionTable to include 8 branch instructions (and 2 instructions for setting/clearing the Carry flag). Added tests in tests.cpp to verify the functionality of the branch instructions.