### PR TITLE
Fixed getTile() method in PPU

### DIFF
--- a/PPU.cpp
+++ b/PPU.cpp
@@ -109,7 +109,7 @@ void PPU::getTile(uint8_t tileIndex, uint16_t* tileData, bool table1) {
 		}
 
 		// Store the combined result
-		((uint16_t*)tileData)[i] = combinedPixels; // Each entry now represents 8 pixels (16 bits)
+		tileData[i] = combinedPixels; // Each entry now represents 8 pixels (16 bits)
 	}
 }
 

--- a/PPU.h
+++ b/PPU.h
@@ -100,7 +100,7 @@ public:
     void writePatternTable(uint16_t addr, uint8_t data);
     
     // method to get a tile, returned as an 8-byte array of pixel info (0-3)
-    void getTile(uint8_t tileIndex, uint8_t* tileData, bool table1);
+    void getTile(uint8_t tileIndex, uint16_t* tileData, bool table1);
 
     void clock();
 


### PR DESCRIPTION
Updated getTile() to (hopefully) properly represent a given tile.

Note that the calling function will need to deconstruct the resulting uint16_t values from the array as pairs of bits.