### PR TITLE
Changed location of sdl2 files on Mac/Homebrew

### DIFF
--- a/UI/imgui/main_ui/main/Makefile
+++ b/UI/imgui/main_ui/main/Makefile
@@ -54,10 +54,10 @@ endif
 ifeq ($(UNAME_S), Darwin) #APPLE
 	ECHO_MESSAGE = "Mac OS X"
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo `sdl2-config --libs`
-	LIBS += -L/usr/local/lib -L/opt/local/lib
+	LIBS += -L/usr/local/lib -L/opt/homebrew/lib
 
 	CXXFLAGS += `sdl2-config --cflags`
-	CXXFLAGS += -I/usr/local/include -I/opt/local/include
+	CXXFLAGS += -I/usr/local/include -I/opt/local/include -I/opt/homebrew/include
 	CFLAGS = $(CXXFLAGS)
 endif
 
@@ -90,3 +90,4 @@ $(EXE): $(OBJS)
 
 clean:
 	rm -f $(EXE) $(OBJS)
+


### PR DESCRIPTION
Homebrew has apparently updated since the creation of the makefile, SDL files are now loacted at opt/homebrew/include not opt/local/lib